### PR TITLE
Update Toggl Track API domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ If no tags are tracked or no all year projects are tracked, these blocks will no
 Download `targets.py`, `config.csv` and `projects.py` to your computer from the repository at <a href="https://github.com/ConorMacBride/toggl-targets">https://github.com/ConorMacBride/toggl-targets</a>. Make sure `targets.py` and `config.csv` are kept in the same folder.
 
 ### Setup configuration file
-Next edit `config.csv` with your own data. Your own API token can be found at `https://toggl.com/app/profile`. This allows this program to access your Toggl data. The refresh rate can also be changed. This is how often the local data is updated.
+Next edit `config.csv` with your own data. Your own API token can be found at `https://track.toggl.com/profile`. This allows this program to access your Toggl data. The refresh rate can also be changed. This is how often the local data is updated.
 
 The next four columns from `SEMESTER NAME` to `WORKLOAD` form the next block of data. Each row represents a 7 day week. There can be no jumps in weeks so include any work-free weeks also. 
 

--- a/index.md
+++ b/index.md
@@ -28,7 +28,7 @@ If no tags are tracked or no all year projects are tracked, these blocks will no
 Download `targets.py`, `config.csv` and `projects.py` to your computer from the repository at <a href="https://github.com/ConorMacBride/toggl-targets">https://github.com/ConorMacBride/toggl-targets</a>. Make sure `targets.py` and `config.csv` are kept in the same folder.
 
 ### Setup configuration file
-Next edit `config.csv` with your own data. Your own API token can be found at `https://toggl.com/app/profile`. This allows this program to access your Toggl data. The refresh rate can also be changed. This is how often the local data is updated.
+Next edit `config.csv` with your own data. Your own API token can be found at `https://track.toggl.com/profile`. This allows this program to access your Toggl data. The refresh rate can also be changed. This is how often the local data is updated.
 
 The next four columns from `SEMESTER NAME` to `WORKLOAD` form the next block of data. Each row represents a 7 day week. There can be no jumps in weeks so include any work-free weeks also. 
 

--- a/projects.py
+++ b/projects.py
@@ -12,7 +12,7 @@ except (ValueError, IndexError) as e:
     print("Toggl API token must be provided!")
     sys.exit(1)
 
-url = 'https://www.toggl.com/api/v8/workspaces'
+url = 'https://api.track.toggl.com/api/v8/workspaces'
 headers = {'content-type': 'application/json'}
 
 # Get workspace

--- a/targets.py
+++ b/targets.py
@@ -165,7 +165,7 @@ def query_toggl():
     :return: numpy array of time entries
     """
     parameters = {'start_date': GLOBAL_START_DATE.isoformat(), 'end_date': current_time().isoformat()}
-    url = 'https://www.toggl.com/api/v8/time_entries'
+    url = 'https://api.track.toggl.com/api/v8/time_entries'
     if len(parameters) > 0:
         url = url + '?{}'.format(urlencode(parameters))
 


### PR DESCRIPTION
This updates the Toggl Track API domain name to the new domain discussed here: https://toggl.com/blog/api-documentation-change. The old domain will stop working on **30th June 2021**, so please update your copy of this code before then.